### PR TITLE
Add asciidoctor-kroki extension to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM docker.io/antora/antora:3.0.0
 COPY ./entrypoint.sh /entrypoint.sh
 
 # install extra antora generators for documentation search and plantuml rendering
-RUN npm i -g antora-site-generator-lunr asciidoctor-plantuml
+RUN npm i -g antora-site-generator-lunr asciidoctor-plantuml asciidoctor-kroki
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
# Summary

Generally on older versions of antora "asciidoctor-plantuml" extension was preferred. Nowadays, npm warns that it is deprecated, therefore no longer used. 
"asciidoctor-kroki" is now preferred to render UML diagrams. 

# Change
- "asciidoctor-kroki" is added to dockerfile